### PR TITLE
doc: remove license todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ When the GitHub Pages URL changes, the file `html/.well-known/csaf/provider-meta
 
 ## License
 
-**todo**
-
 ```
 SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
license is clarified, todo is obsolete