### PR TITLE
ci: update action versions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Run codespell
       uses: codespell-project/actions-codespell@v2
       with:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: REUSE compliance check
       uses: fsfe/reuse-action@v6

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Extract commands
         run: ./update_local_execution.sh
       - name: Run ShellCheck

--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
   using: composite
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         sparse-checkout: ${{ inputs.source_csaf_documents }}
         path: source
@@ -113,7 +113,7 @@ runs:
         json_tlps=$(echo ${{ inputs.tlps }} | jq -cR 'split(",")')
 
     - name: Checkout target branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: "${{ inputs.target_branch }}"
         # make a checkout in different directory. Not possible in parallel directory (permissions). A subdirectory may collide with existing directory names
@@ -311,7 +311,7 @@ runs:
 
     - name: Commit changes
       # Use https://github.com/stefanzweifel/git-auto-commit-action for commit and push
-      uses: stefanzweifel/git-auto-commit-action@v6
+      uses: stefanzweifel/git-auto-commit-action@v7
       with:
         commit_message: Update CSAF advisories
         repository: target


### PR DESCRIPTION
stefanzweifel/git-auto-commit-action@v6 triggered a deprecation warning on Node.js 20

also update the checkout actions