### PR TITLE
feat: add parameter to pass openpgp key passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ jobs:
 | `openpgp_key_length` | No | `4096` | If the OpenPGP is to be generated on the fly, this is the key length in bits. |
 | `openpgp_secret_key` | No | - | The armored OpenPGP secret key, provided as GitHub secret. |
 | `openpgp_public_key` | No | - | The armored OpenPGP public key, provided as string or GitHub secret. |
+| `openpgp_passphrase` | No | - | The passphrase to unlock the OpenPGP secret key, provided as GitHub secret. |
 | `generate_index_files` | No | `false` | Generate index.html files in .well-known/csaf/ for easier navigation in the browser. Otherwise GitHub will give 404s when accessing the directories directly. |
 | `target_branch` | No | `gh-pages` | The target branch to push the resulting data to. |
 | `tlps` | No | `csaf,white` | Set the TLP levels allowed to be send with the upload request. Possible levels: "csaf", "white", "amber", "green", "red". The "csaf" entry lets the provider take the value from the CSAF document. |
@@ -138,11 +139,25 @@ with:
   openpgp_public_key: ${{ secrets.CSAF_OPENPGP_PUBLIC_KEY }}
 ```
 
+If your private key is protected with a passphrase, add it as a third secret (e.g. `CSAF_OPENPGP_PASSPHRASE`) and pass it via `openpgp_passphrase`:
+
+```yaml
+with:
+  openpgp_use_signatures: false
+  openpgp_secret_key: ${{ secrets.CSAF_OPENPGP_SECRET_KEY }}
+  openpgp_public_key: ${{ secrets.CSAF_OPENPGP_PUBLIC_KEY }}
+  openpgp_passphrase: ${{ secrets.CSAF_OPENPGP_PASSPHRASE }}
+```
+
 ##### Security
 
 As the OpenPGP key needs to be provided unencrypted at GitHub, keep in mind that GitHub/Microsoft can read and use it.
 Please create a specific OpenPGP key for this purpose, do not reuse any other existing key and prepare for a potential confidentiality breach.
 Keep the revocation certificate ready in case you need to revoke the key.
+
+Providing a passphrase for the Open PGP private key does not improve security.
+This option exists purely for tools that always export private keys with a passphrase.
+It removes the need to strip the passphrase from it manually before uploading the key as a secret.
 
 #### Generating key on the fly
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,9 @@ inputs:
   openpgp_public_key:
     description: The armored OpenPGP public key, provided as GitHub secret
     required: false
+  openpgp_passphrase:
+    description: The passphrase to unlock the OpenPGP secret key, provided as GitHub secret
+    required: false
   generate_index_files:
     description: Generate index.html files in .well-known/csaf/ for easier navigation in the browser. Otherwise GitHub will give 404s when accessing the directories directly.
     default: false
@@ -292,14 +295,24 @@ runs:
       shell: bash
       run: |
         set -x
-        find "$GITHUB_WORKSPACE/source/${{ inputs.source_csaf_documents }}" -type f -name '*.json' -print0 | while IFS= read -r -d $'\0' file; do
+        uploader_config_args=()
+        if [[ -n "${{ inputs.openpgp_passphrase }}" ]]; then
+          # Write passphrase to config file so it is not exposed on the command line or in logs
+          uploader_config=$(mktemp --suffix=.toml)
+          # use printf to prevent interpretation of characters in the passphrase
+          printf 'passphrase = "%s"\n' "${{ inputs.openpgp_passphrase }}" > "$uploader_config"
+          chmod 600 "$uploader_config"
+          uploader_config_args=(--config "$uploader_config")
+        fi
+        while IFS= read -r -d $'\0' file; do
           echo "Uploading $file"
           # we cannot quote around the parameter expansion of openpgp_use_signatures as then csaf_upload would get an empty string as parameter if openpgp_use_signatures is not set
           # shellcheck disable=SC2046
           "./csaf-${{ env.csaf_version }}-gnulinux-amd64/bin-linux-amd64/csaf_uploader" \
+            "${uploader_config_args[@]}" \
             --action upload --url http://127.0.0.1/cgi-bin/csaf_provider.go --password password \
             "$file" $( [[ "${{ inputs.openpgp_use_signatures }}" == "true" ]] && echo "--external_signed" )
-        done
+        done < <(find "$GITHUB_WORKSPACE/source/${{ inputs.source_csaf_documents }}" -type f -name '*.json' -print0)
 
 
         tree_version=$(tree --version | grep -Eo 'v[0-9.]+')

--- a/local_execution.sh
+++ b/local_execution.sh
@@ -19,6 +19,7 @@ openpgp_key_type="RSA"
 openpgp_key_length="4096"
 openpgp_secret_key=""
 openpgp_public_key=""
+openpgp_passphrase=""
 generate_index_files="false"
 target_branch="gh-pages"
 tlps="csaf,white"
@@ -181,14 +182,24 @@ echo $secvisogram_pid > secvisogram.pid
 wait-for-it localhost:8082
 
 set -x
-find "${HOME}/source/${source_csaf_documents}" -type f -name '*.json' -print0 | while IFS= read -r -d $'\0' file; do
+uploader_config_args=()
+if [[ -n "${openpgp_passphrase}" ]]; then
+  # Write passphrase to config file so it is not exposed on the command line or in logs
+  uploader_config=$(mktemp --suffix=.toml)
+  # use printf to prevent interpretation of characters in the passphrase
+  printf 'passphrase = "%s"\n' "${openpgp_passphrase}" > "$uploader_config"
+  chmod 600 "$uploader_config"
+  uploader_config_args=(--config "$uploader_config")
+fi
+while IFS= read -r -d $'\0' file; do
   echo "Uploading $file"
   # we cannot quote around the parameter expansion of openpgp_use_signatures as then csaf_upload would get an empty string as parameter if openpgp_use_signatures is not set
   # shellcheck disable=SC2046
   "./csaf-$csaf_version-gnulinux-amd64/bin-linux-amd64/csaf_uploader" \
+    "${uploader_config_args[@]}" \
     --action upload --url http://127.0.0.1/cgi-bin/csaf_provider.go --password password \
     "$file" $( [[ "${openpgp_use_signatures}" == "true" ]] && echo "--external_signed" )
-done
+done < <(find "${HOME}/source/${source_csaf_documents}" -type f -name '*.json' -print0)
 
 
 tree_version=$(tree --version | grep -Eo 'v[0-9.]+')


### PR DESCRIPTION
implements https://github.com/csaf-tools/csaf-action/issues/18

Tests are run in https://github.com/csaf-tools/csaf-action-test/actions/runs/25933802321/job/76233991883

Excerpt:

```
+ uploader_config_args=()
+ [[ -n *** ]]
++ mktemp --suffix=.toml
+ uploader_config=/tmp/tmp.yHS9UyvUUV.toml
+ printf '*** = "%s"\n' ***
+ chmod 600 /tmp/tmp.yHS9UyvUUV.toml
+ uploader_config_args=(--config "$uploader_config")
+ IFS=
+ read -r -d '' file
++ find /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/ -type f -name '*.json' -print0
+ echo 'Uploading /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/example-company-2025-0001.json'
Uploading /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/example-company-2025-0001.json
++ [[ false == \t\r\u\e ]]
+ ./csaf-3.5.1-gnulinux-amd64/bin-linux-amd64/csaf_uploader --config /tmp/tmp.yHS9UyvUUV.toml --action upload --url http://127.0.0.1/cgi-bin/csaf_provider.go --password password /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/example-company-2025-0001.json
Name: example-company-2025-0001.json
Release date: 2025-07-31T12:00:00Z
Warnings:
	Publishers in provider metadata and CSAF do not match.
+ IFS=
+ read -r -d '' file
+ echo 'Uploading /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/example-company-2025-0002.json'
Uploading /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/example-company-2025-0002.json
++ [[ false == \t\r\u\e ]]
+ ./csaf-3.5.1-gnulinux-amd64/bin-linux-amd64/csaf_uploader --config /tmp/tmp.yHS9UyvUUV.toml --action upload --url http://127.0.0.1/cgi-bin/csaf_provider.go --password password /home/runner/work/csaf-action-test/csaf-action-test/source/test/inputs/example-company-2025-0002.json
Name: example-company-2025-0002.json
Release date: 2025-07-31T12:00:00Z
Warnings:
	Publishers in provider metadata and CSAF do not match.
+ IFS=
+ read -r -d '' file
```